### PR TITLE
Fix event binding edge case

### DIFF
--- a/ui-map.js
+++ b/ui-map.js
@@ -92,7 +92,9 @@
         restrict: 'A',
         link: function (scope, elm, attrs) {
           scope.$watch(attrs[directiveName], function (newObject) {
-            bindMapEvents(scope, events, newObject, elm);
+            if (newObject) {
+              bindMapEvents(scope, events, newObject, elm);
+            }
           });
         }
       };


### PR DESCRIPTION
inside an ng-repeat, when the collection is empty the watch still gets triggered, but with undefined as value. We shouldn't bind events in this case.
