### PR TITLE
fix: Removed map- prefix from event names

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -5,10 +5,8 @@
   //then we just use ui-event to catch events from an element
   function bindMapEvents(scope, eventsStr, googleObject, element) {
     angular.forEach(eventsStr.split(' '), function (eventName) {
-      //Prefix all googlemap events with 'map-', so eg 'click' 
-      //for the googlemap doesn't interfere with a normal 'click' event
       google.maps.event.addListener(googleObject, eventName, function (event) {
-        element.triggerHandler('map-' + eventName, event);
+        element.triggerHandler(eventName, event);
         //We create an $apply if it isn't happening. we need better support for this
         //We don't want to use timeout because tons of these events fire at once,
         //and we only need one $apply

--- a/test/mapSpec.js
+++ b/test/mapSpec.js
@@ -40,12 +40,12 @@ describe('uiMap', function () {
       expect(scope.gmap.getCenter()).toBe(center);
     });
 
-    it('should pass events to the element as "map-eventname"', function () {
+    it('should pass events to the element as "eventname"', function () {
       scope.zoomy = false;
       scope.county = 0;
       createMap({}, {
-        'map-zoom_changed': 'zoomy = true',
-        'map-dblclick map-dragend': 'county = county + 1'
+        'zoom_changed': 'zoomy = true',
+        'dblclick dragend': 'county = county + 1'
       });
       google.maps.event.trigger(scope.gmap, 'zoom_changed');
       expect(scope.zoomy).toBeTruthy();
@@ -89,13 +89,16 @@ describe('uiMap', function () {
       expect(inner.val()).toBe('final');
     });
 
-    it('should recognize infowindow events in ui-event as "map-eventname"', function () {
+    it('should recognize infowindow events in ui-event as "eventname"', function () {
       expect(scope.closed).toBeUndefined();
+      dump(scope.closed);
       createWindow({}, {
-        'map-closeclick': 'closed = true'
+        'closeclick': 'closed = true'
       });
       createMap();
+      dump(scope.closed);
       google.maps.event.trigger(scope.ginfo, 'closeclick');
+      dump(scope.ginfo);
       expect(scope.closed).toBe(true);
     });
   });


### PR DESCRIPTION
I didn't see a reason to keep the prefix as the original DOM elements
are not used for anything else

This is a Pull Request because it's a destructive change. If anyone disagrees please make your voice known.
