### PR TITLE
Adding support for InfoBubble: a more customizable infowindow.

### DIFF
--- a/src/ui-map.js
+++ b/src/ui-map.js
@@ -81,6 +81,43 @@
       };
     }]);
 
+	/*
+	 * Support for Infobubble [http://google-maps-utility-library-v3.googlecode.com/svn/trunk/infobubble/]
+	 * "A InfoBubble is a customizable css3 infowindow."
+	 * Fully customizable with support for tabs
+	*/
+	app.directive('uiMapInfoBubble',
+      ['ui.config', '$parse', '$compile', function (uiConfig, $parse, $compile) {
+
+          var infoBubbleEvents = 'closeclick content_change domready ' +
+            'position_changed zindex_changed';
+          var options = uiConfig.mapInfoBubble || {};
+          window.infoBubbleOptions = options;
+          return {
+              link: function (scope, elm, attrs) {
+                  var opts = angular.extend({}, options, scope.$eval(attrs.uiOptions));
+                  opts.content = elm[0];
+                  var model = $parse(attrs.uiMapInfoBubble);
+                  var infoBubble = model(scope);
+
+                  window.infoBubbleOptions = opts;
+                  if (!infoBubble) {
+                      infoBubble = new InfoBubble(opts);
+                      model.assign(scope, infoBubble);
+                  }
+
+                  bindMapEvents(scope, infoBubbleEvents, infoBubble, elm);
+
+                  //Decorate infoWindow.open to $compile contents before opening
+                  var _open = infoBubble.open;
+                  infoBubble.open = function open(a1, a2, a3, a4, a5, a6) {
+                        //$compile(elm.contents())(scope);
+                      _open.call(infoBubble, a1, a2, a3, a4, a5, a6);
+			    };
+		    }
+	    };
+    }]);
+	  
   /*
    * Map overlay directives all work the same. Take map marker for example
    * <ui-map-marker="myMarker"> will $watch 'myMarker' and each time it changes,


### PR DESCRIPTION
Tests are broken due to "Infobubble is not defined", please advice how to handle this.
Currently doesn't work with "Controller As" syntax, would love to get help to fix this
There's a quirk with only the first bubble being hidden on start, hence the need for HasMapMenuBeenOpened

Usage:

<div ng-controller="MapCtrl">
    <div ui-map-info-bubble="MapMenu" ui-options="MapMenuOptions">
        <div class="mapMenu">
            <div ng-controller="MapMenuCtrl" ng-show="HasMapMenuBeenOpened">
                <div ng-click="AddLocation()">Add Location</div>
            </div>
        </div>
    </div>
    <div id="map_canvas" ui-map="MyMap" class="map"
        ui-event="{ 'map-click':'OpenMapMenu($event.latLng)'   }">
    </div>
</div>


$scope.OpenMapMenu = function (latLng) {
            $scope.HasMapMenuBeenOpened = true;

```
        var marker = new google.maps.Marker({
            map: $scope.MyMap,
            position: latLng,
            icon: '/Content/Images/Markers/Empty.png'
        });

        $scope.MapMenu.open($scope.MyMap, marker);
    };
```
